### PR TITLE
Ensure the blog gets an image URL

### DIFF
--- a/inc/functions-amp.php
+++ b/inc/functions-amp.php
@@ -58,5 +58,7 @@ function change_yoast_amp_urls( $url ) {
 
 	if ( is_amp() ) {
 		return str_replace( 'blog.nationalarchives', 'media.nationalarchives', $url );
+	} else {
+		return $url;
 	}
 }


### PR DESCRIPTION
While checking for the platform you need to ensure that the blog image url is getting returned

Fix for issue #32 